### PR TITLE
fix(definitions): Make sure the line endings are read as LF

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -200,7 +200,7 @@ function copy(cb) {
 async function prepareBuild(cb) {
 
     // Create the typescript definitions
-    const DTSSource = DTSFiles.map(f => `${outPath}/${f}`).map(f => fs.readFileSync(f, {encoding: 'utf8'})).join('\n');
+    const DTSSource = DTSFiles.map(f => `${outPath}/${f}`).map(f => fs.readFileSync(f, {encoding: 'utf8'}).replace(/\r\n/g, '\n')).join('\n');
     const DTS = createTypeScriptDefinitionsWithContent(DTSSource);
 
     // Remove unneeded files


### PR DESCRIPTION
Since git may replace LF with CRLF on checkout, this will break the dts generation that depends on LF line endings.
This change forces the dts generation to read the files with LF line endings